### PR TITLE
fix Blisk link

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ The setup process will:
 <details>
 <summary>Browsers</summary>
 
-* [Blisk](https://www.blisk.io/) for cross-device web development.
+* [Blisk](https://blisk.io/) for cross-device web development.
 * [Brave](https://brave.com/) for web browsing without ads.
 * [Chrome](https://www.google.com/chrome/browser/desktop/) for fast and free web browsing.
 * [Firefox](https://www.mozilla.org/en-US/firefox/new/) for web browsing and testing.


### PR DESCRIPTION
Looks like Blisk doesn't have `www` correctly configured as a subdomain, plus Chrome throws a "Your connection is not private" warning. https://blisk.io appears to work fine though!