### PR TITLE
Remove deprecated & breaking brew cask command

### DIFF
--- a/slay
+++ b/slay
@@ -193,7 +193,6 @@ fi
 ###############################################################################
 chapter "Cleaning up Homebrew files…"
 brew cleanup 2> /dev/null
-brew cask cleanup 2> /dev/null
 
 ###############################################################################
 # INSTALL: npm packages


### PR DESCRIPTION
Removes `brew cask cleanup` since it is [deprecated](https://github.com/Homebrew/brew/issues/4660) and causing a fatal error in the script. The same functionality should be provided in `brew cleanup`.