### PR TITLE
Adding more repositories to the list of homebrew formulae via taps

### DIFF
--- a/slay
+++ b/slay
@@ -135,6 +135,17 @@ if brew list | grep -Fq brew-cask; then
 fi
 
 ###############################################################################
+# ADD: brew taps
+###############################################################################
+if [ -e $cwd/swag/taps ]; then
+	chapter "Adding repositories to Homebrew formulae…"
+
+	for tap in $(<$cwd/swag/taps); do
+	    add_brew_taps $tap
+	done
+fi
+
+###############################################################################
 # INSTALL: brews
 ###############################################################################
 if [ -e $cwd/swag/brews ]; then

--- a/twirl
+++ b/twirl
@@ -483,6 +483,16 @@ ask() {
 # 
 ###############################################################################
 
+add_brew_taps() {
+    if test ! $(brew tap | grep $tap); then
+        echo_install "Adding $tap to Homebrew"
+		brew tap $tap >/dev/null
+		print_in_green "${bold}✓ added!${normal}\n"
+	else
+		print_success_muted "$tap already added. Skipped."
+    fi
+}
+
 # return 1 if global command line program installed, else 0
 cli_is_installed() {
     # set to 1 initially


### PR DESCRIPTION
### What's Changed

Enables adding more repositories to the list of homebrew formulae via `taps` using `swag/taps`. 

> [`brew tap`](https://docs.brew.sh/Taps) adds more repositories to the list of formulae that brew tracks, updates, and installs from. By default, tap assumes that the repositories come from GitHub, but the command isn’t limited to any one location.

### Example

[`prisma`](https://www.prisma.io/docs/prisma-cli-and-configuration/using-the-prisma-cli-alx4/#installation) can be installed via Homebrew however it requires the formulae to be added to Homebrew prior to installing. Outside of formation, this would be achieved using the following commands:

```
brew tap prisma/prisma
brew install prisma
```

However, the following PR provide equivalent support by defining `prisma/prisma` within `swag/taps` file and `prisma` within `swag/brews`. 

### Installation Demo

[![asciicast](https://asciinema.org/a/Aks9PltTTTzHUaRPapc7yUaDI.svg)](https://asciinema.org/a/Aks9PltTTTzHUaRPapc7yUaDI)

The following is something my team and I needed earlier in the week, we forked formation and made the change and decided to contribute it back upstream as #9 appeared to be inactive. If there is anything I can do to help get this PR accepted, please let me know.  

Finally, thank you @minamarkham for an awesome piece of software; it's saved my team and I hours of effort in setting up time :)