### PR TITLE
fixed NVM installation issue

### DIFF
--- a/slay
+++ b/slay
@@ -104,7 +104,6 @@ fi
 # -----------------------------------------------------------------------------
 if ! [ -e $NVM_DIR ]; then
 	step "Installing NVM…"
-	# ensures that nvm 
 	touch ~/.bash_profile
 	curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | bash
 	# This loads nvm for the terminal session

--- a/slay
+++ b/slay
@@ -102,9 +102,15 @@ fi
 # -----------------------------------------------------------------------------
 # NVM
 # -----------------------------------------------------------------------------
-if [ -x nvm ]; then
+if ! [ -e $NVM_DIR ]; then
 	step "Installing NVM…"
-	curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
+	# ensures that nvm 
+	touch ~/.bash_profile
+	curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | bash
+	# This loads nvm for the terminal session
+	export NVM_DIR="$HOME/.nvm"
+	[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  
+	[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  
 	print_success "NVM installed!"
 	step "Installing latest Node…"
 	nvm install node


### PR DESCRIPTION
While install on a fresh Mojave installation I ran into two issues: 1) NVM was getting skipped and 2) installation did  work because `~/.bash_profile` did not exist. 

This fix resolves both issues by checking for existance of `NVM_DIR` to see if `nvm` is installed and creating the `~/.bash_profile` if it doesn't already exist. It also loads nvm for the session to insure that node and the npm packages get installed gets installed. Also NVM gets a version bump
 
Fixes #7 