### PR TITLE
Perform exact word match on brew + grep

### DIFF
--- a/twirl
+++ b/twirl
@@ -480,7 +480,7 @@ ask() {
 }
 
 ###############################################################################
-# 
+#
 ###############################################################################
 
 # return 1 if global command line program installed, else 0
@@ -546,7 +546,7 @@ gem_install_or_update() {
 }
 
 install_brews() {
-    if test ! $(brew list | grep $brew); then
+    if test ! $(brew list | grep -x $brew); then
         echo_install "Installing $brew"
 		brew install $brew >/dev/null
 		print_in_green "${bold}✓ installed!${normal}\n"


### PR DESCRIPTION
Example: if looking for “git” and there is “git” and “gitish” on the results list, this command will complain because `grep` encounters more than one match. This fix makes sure it matches on the whole word.

Without this flag, I was getting more than one matches with the words `git` and `heroku`:
```
✦  4. Installing Homebrew formulae…
└─────────────────────────────────────────────────────○
  [↓] Installing asciinema Updating Homebrew...
✓ installed!
  [✓] fish already installed. Skipped.
twirl: line 549: test: git: unary operator expected
  [✓] git already installed. Skipped.
twirl: line 549: test: heroku-node: binary operator expected
```

P.S.: Thanks for this repo, super useful to set up new MacBooks! 🙌 